### PR TITLE
Bump actions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -33,7 +33,7 @@ jobs:
         run: make
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: fh2_matt_bakers_texture_pack_${{ github.ref_name }}.zip
           path: ./dist/fh2_matt_bakers_texture_pack_${{ github.ref_name }}.zip
@@ -47,11 +47,11 @@ jobs:
       contents: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: fh2_matt_bakers_texture_pack_${{ github.ref_name }}.zip
       - name: Publish release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: Release ${{ github.ref_name }}
           generate_release_notes: true


### PR DESCRIPTION
Updates actions (some were deprecated and not working anymore):

- `actions/upload-artifact@v4`
- `actions/dowmload-artifact@v4`
- `softprops/action-gh-release@v2`